### PR TITLE
fix: use the logical stand numbering for stand identifier instead of source internal id

### DIFF
--- a/lukefi/metsi/data/formats/ForestBuilder.py
+++ b/lukefi/metsi/data/formats/ForestBuilder.py
@@ -508,7 +508,7 @@ class ForestCentreBuilder(XMLBuilder):
             estrata = estand.findall(self.xpath_strata, smk_util.NS)
             for estratum in estrata:
                 stratum = self.convert_stratum_entry(estratum)
-                stratum.identifier = "{}-{}-stratum".format(stand.identifier, stratum.identifier)
+                stratum.identifier = f"{stand.identifier}.{stratum.tree_number or stratum.identifier}-stratum"
                 strata.append(stratum)
             stand.tree_strata = strata
             stands.append(stand)

--- a/lukefi/metsi/data/formats/smk_util.py
+++ b/lukefi/metsi/data/formats/smk_util.py
@@ -27,9 +27,21 @@ NS = {
     }
 
 
+def generate_stand_identifier(xml_stand: Element) -> str:
+    stand_identifier = xml_stand.attrib.get('id')
+    stand_number = xml_stand.findtext('./st:StandBasicData/st:StandNumber', None, NS)
+    stand_number_extension = xml_stand.findtext('./st:StandBasicData/st:StandNumberExtension', None, NS)
+    if stand_number and stand_number_extension:
+        return f"{stand_number}.{stand_number_extension}"
+    elif stand_number:
+        return stand_number
+    elif stand_identifier:
+        return stand_identifier
+
+
 def parse_stand_basic_data(xml_stand: Element) -> SimpleNamespace:
     sns = SimpleNamespace()
-    sns.id = xml_stand.attrib['id']
+    sns.id = generate_stand_identifier(xml_stand)
     sns.CompleteState = xml_stand.findtext('./st:StandBasicData/st:CompleteState', None, NS)
     sns.StandBasicDataDate = xml_stand.findtext('./st:StandBasicData/st:StandBasicDataDate', None, NS)
     sns.Area = xml_stand.findtext('./st:StandBasicData/st:Area', None, NS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "lukefi.metsi.data"
 description = "Data structures and transformation functionality for forest data formats."
-version = "1.0.0"
+version = "1.0.1"
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [

--- a/tests/smk_builder_test.py
+++ b/tests/smk_builder_test.py
@@ -36,8 +36,8 @@ class TestForestCentreBuilder(unittest.TestCase):
         self.assertEqual(2, len(self.smk_stands))
 
     def test_smk_builder_stand_identifiers(self):
-        self.assertEqual('100', self.smk_stands[0].identifier)
-        self.assertEqual('101', self.smk_stands[1].identifier)
+        self.assertEqual('10', self.smk_stands[0].identifier)
+        self.assertEqual('15', self.smk_stands[1].identifier)
 
     def test_smk_builder_stand_variables(self):
         # TODO: implement parse logic for management unit id
@@ -51,8 +51,8 @@ class TestForestCentreBuilder(unittest.TestCase):
         self.assertEqual(0.45, self.smk_stands[1].area_weight)
         self.assertEqual((6542843.0, 532437.0, None, 'EPSG:3067'), self.smk_stands[0].geo_location)
         self.assertEqual((6532843.0, 536437.0, None, 'EPSG:3067'), self.smk_stands[1].geo_location)
-        self.assertEqual('100', self.smk_stands[0].identifier)
-        self.assertEqual('101', self.smk_stands[1].identifier)
+        self.assertEqual('10', self.smk_stands[0].identifier)
+        self.assertEqual('15', self.smk_stands[1].identifier)
         # TODO: verify the default value of degree days
         self.assertEqual(None, self.smk_stands[0].degree_days)
         self.assertEqual(None, self.smk_stands[1].degree_days)
@@ -134,8 +134,8 @@ class TestForestCentreBuilder(unittest.TestCase):
         self.assertEqual(0, len(self.smk_stands[1].tree_strata))
 
     def test_smk_builder_stratum_identifiers(self):
-        self.assertEqual('100-331-stratum', self.smk_stands[0].tree_strata[0].identifier)
-        self.assertEqual('100-332-stratum', self.smk_stands[0].tree_strata[1].identifier)
+        self.assertEqual('10-331-stratum', self.smk_stands[0].tree_strata[0].identifier)
+        self.assertEqual('10-332-stratum', self.smk_stands[0].tree_strata[1].identifier)
         self.assertEqual(0, len(self.smk_stands[1].tree_strata))
 
     def test_smk_builder_stratum_variables(self):

--- a/tests/smk_builder_test.py
+++ b/tests/smk_builder_test.py
@@ -134,8 +134,8 @@ class TestForestCentreBuilder(unittest.TestCase):
         self.assertEqual(0, len(self.smk_stands[1].tree_strata))
 
     def test_smk_builder_stratum_identifiers(self):
-        self.assertEqual('10-331-stratum', self.smk_stands[0].tree_strata[0].identifier)
-        self.assertEqual('10-332-stratum', self.smk_stands[0].tree_strata[1].identifier)
+        self.assertEqual('10.1-stratum', self.smk_stands[0].tree_strata[0].identifier)
+        self.assertEqual('10.2-stratum', self.smk_stands[0].tree_strata[1].identifier)
         self.assertEqual(0, len(self.smk_stands[1].tree_strata))
 
     def test_smk_builder_stratum_variables(self):

--- a/tests/smk_util_test.py
+++ b/tests/smk_util_test.py
@@ -65,6 +65,28 @@ class TestSmkXMLConversion(test_util.ConverterTestSuite):
         sns = smk_util.parse_stand_basic_data(reference_stand)
         self.assertEqual(assertion, sns)
 
+    def test_parse_stand_identifier_via_stand_number_extension(self):
+        test_element = """
+            <st:StandNumber>123</st:StandNumber>
+            <st:StandNumberExtension>124</st:StandNumberExtension>
+        """
+        reference_stand = generate_test_data(stand_data_element=test_element)
+        sns = smk_util.parse_stand_basic_data(reference_stand)
+        self.assertEqual("123.124", sns.id)
+
+    def test_parse_stand_identifier_via_stand_number(self):
+        test_element = """
+            <st:StandNumber>123</st:StandNumber>
+        """
+        reference_stand = generate_test_data(stand_data_element=test_element)
+        sns = smk_util.parse_stand_basic_data(reference_stand)
+        self.assertEqual("123", sns.id)
+
+    def test_parse_stand_identifier_with_fallback_id(self):
+        test_element = ''
+        reference_stand = generate_test_data(stand_data_element=test_element)
+        sns = smk_util.parse_stand_basic_data(reference_stand)
+        self.assertEqual("111", sns.id)
 
     def test_parse_stand_operation_data(self):
         ...


### PR DESCRIPTION
For XML based ForestStand objects, identifier is now in set in order of precedence from the source file Stand attribute availability:

1) {StandNumber}.{StandNumberExtension}
2) {StandNumber}
3) {id}

For XML based TreeStratum objects, identifier is now set in order of precedence from the source file TreeStratum attribute availability, where stand.identifier is the identifier generated with rules above:

1) {stand.identifier}.{StratumNumber}-stratum
2) {stand.identifier}.{id}-stratum

closing #1

For changes to take effect I will need to update Metsi dependency after this PR is merged.